### PR TITLE
Extend Documentation, Add Test Tasks, Extract Release Job in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,20 +58,3 @@ jobs:
           bundle install
           bundle exec rake
           sha1sum --check .test-map.yml.sha1
-
-  release:
-    if: github.ref == 'refs/heads/main'
-    needs: [lint, test, verify]
-    name: Push gem to RubyGems.org
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: ruby
-      - uses: rubygems/release-gem@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+---
+
+name: Main Pipeline
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/main'
+    needs: [lint, test, verify]
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - uses: rubygems/release-gem@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.bundle/
 /pkg/
+/coverage/

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+SimpleCov.start do
+  add_filter 'test/'
+  enable_coverage :branch
+end

--- a/.test-map.yml
+++ b/.test-map.yml
@@ -3,7 +3,7 @@ lib/test_map/config.rb:
 - test/test_map/config_test.rb
 - test/test_map/file_recorder_test.rb
 - test/test_map/filter_test.rb
-- test/test_map/mapping_test.rb
+- test/test_map/natural_mapping_test.rb
 lib/test_map/errors.rb:
 - test/test_map/errors_test.rb
 - test/test_map/file_recorder_test.rb
@@ -35,6 +35,8 @@ lib/test_map/plugins/minitest.rb:
 - test/test_map_test.rb
 lib/test_map/report.rb:
 - test/test_map/report_test.rb
+test/fixtures/sample.rb:
+- test/test_map/file_recorder_test.rb
 test/test_map/config_test.rb:
 - test/test_map/config_test.rb
 test/test_map/file_recorder_test.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'rake', '~> 13.0'
 gem 'rubocop', '~> 1.66'
 gem 'rubocop-minitest', '~> 0.36.0'
 gem 'rubocop-rake', '~> 0.6.0'
+gem 'simplecov', '~> 0.22.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
+    docile (1.4.1)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)
@@ -41,6 +42,12 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     unicode-display_width (2.6.0)
 
 PLATFORMS
@@ -54,6 +61,7 @@ DEPENDENCIES
   rubocop (~> 1.66)
   rubocop-minitest (~> 0.36.0)
   rubocop-rake (~> 0.6.0)
+  simplecov (~> 0.22.0)
   test-map!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ TestMap::TestTask.create
 Using [entr](https://eradman.com/entrproject/) as example file watcher.
 
 ```sh
+# find all ruby files | watch them, postpone first execution, clear screen
+#   with every run and on file change run test suite for the changed file
+#   (placeholder /_).
 $ find . -name "*.rb" | entr -cp bundle exec rake test:changes /_
 ```
 
@@ -95,6 +98,7 @@ Open list of features:
 - [ ] Auto-handle packs, packs with subdirectories.
 - [ ] Demonstrate usage with file watchers.
 - [ ] Demonstrate CI pipelines with GitHub actions and GitLab CI.
+- [ ] Merge results.
 
 ```sh
 $ bundle install # install dependencies

--- a/README.md
+++ b/README.md
@@ -19,20 +19,6 @@ Add test-map to your Gemfile.
 $ bundle add test-map
 ```
 
-On demand you can adapt the configuration to your needs.
-
-```ruby
-TestMap::Configure.configure do |config|
-  config.logger = Logger.new($stdout) # default logs to dev/null
-  config.out_file = 'my-test-map.yml' # default is .test-map.yml
-  # defaults to [%r{^(vendor|test|spec)/}] }
-  config.exclude_patterns = [%r{^(libraries|testsuite)/}]
-  # register a custom rule to match new files; must implement `call(file)`;
-  # defaults to nil
-  config.natural_mapping = ->(file) { file.sub(%r{^library/}, 'test/') }
-end
-```
-
 ### Minitest
 
 Include test-map in your test helper. Typically you want to include it
@@ -53,6 +39,22 @@ $ TEST_MAP=1 bundle exec ruby -Itest test/models/user_test.rb
 $ TEST_MAP=1 bundle exec rake test
 ```
 
+Using the a dedicated rake task you can connect a file watcher and trigger
+tests on file changes.
+
+```ruby
+# filename: Rakefile
+require 'test_map/test_task'
+
+TestMap::TestTask.create
+```
+
+Using [entr](https://eradman.com/entrproject/) as example file watcher.
+
+```sh
+$ find . -name "*.rb" | entr -cp bundle exec rake test:changes /_
+```
+
 ### Rspec
 
 Include test-map in your test helper. Typically you want to include it
@@ -69,7 +71,30 @@ Run your tests with the `TEST_MAP` environment variable set.
 $ TEST_MAP=1 bundle exec rspec
 ```
 
+## Configuration
+
+On demand you can adapt the configuration to your needs.
+
+```ruby
+TestMap::Configure.configure do |config|
+  config.logger = Logger.new($stdout) # default logs to dev/null
+  config.out_file = 'my-test-map.yml' # default is .test-map.yml
+  # defaults to [%r{^(vendor)/}] }
+  config.exclude_patterns = [%r{^(vendor|other_libraries)/}]
+  # register a custom rule to match new files; must implement `call(file)`;
+  # defaults to nil
+  config.natural_mapping = ->(file) { file.sub(%r{^library/}, 'test/') }
+end
+```
+
 ## Development
+
+Open list of features:
+
+- [ ] Configure file exclude list (e.g. test files are not needed).
+- [ ] Auto-handle packs, packs with subdirectories.
+- [ ] Demonstrate usage with file watchers.
+- [ ] Demonstrate CI pipelines with GitHub actions and GitLab CI.
 
 ```sh
 $ bundle install # install dependencies
@@ -79,5 +104,5 @@ $ bundle exec rubocop # run linter
 
 ## Contributing
 
-Bug reports and pull requests are welcome on
+Bug reports and pull requests are very welcome on
 [GitHub](https://github.com/unused/test-map).

--- a/lib/test_map/config.rb
+++ b/lib/test_map/config.rb
@@ -11,7 +11,8 @@ module TestMap
 
     def self.default_config
       { logger: Logger.new('/dev/null'), out_file: '.test-map.yml',
-        exclude_patterns: [%r{^(vendor)/}], natural_mapping: nil }
+        exclude_patterns: [%r{^(vendor)/}], natural_mapping: nil,
+        skip_files: [%r{^(test/)}], merge: false }
     end
   end
 end

--- a/lib/test_map/file_recorder.rb
+++ b/lib/test_map/file_recorder.rb
@@ -5,13 +5,19 @@ module TestMap
   class FileRecorder
     def initialize = @files = []
 
-    def trace
+    def trace(&block)
       raise TraceInUseError.default if @trace&.enabled?
 
       @trace = TracePoint.new(:call) do |tp|
         TestMap.logger.debug "#{tp.path}:#{tp.lineno}"
         @files << tp.path
-      end.tap(&:enable)
+      end
+
+      if block_given?
+        @trace.enable { block.call }
+      else
+        @trace.enable
+      end
     end
 
     def stop = @trace&.disable

--- a/lib/test_map/plugins/rspec.rb
+++ b/lib/test_map/plugins/rspec.rb
@@ -5,10 +5,8 @@ TestMap.logger.info 'Loading RSpec plugin'
 RSpec.configure do |config|
   config.around(:example) do |example|
     # path = example.metadata[:example_group][:file_path]
-    recorder = TestMap::FileRecorder.new.tap(&:trace)
-    example.run
-  ensure
-    recorder.stop
+    recorder = TestMap::FileRecorder.new
+    recorder.trace { example.run }
     TestMap.reporter.add recorder.results
   end
 

--- a/lib/test_map/report.rb
+++ b/lib/test_map/report.rb
@@ -15,6 +15,12 @@ module TestMap
       end
     end
 
+    def write(file)
+      result = to_yaml
+      result = YAML.safe_load_file(file).deep_merge(result) if Config.config[:merge]
+      File.write file, result
+    end
+
     def results = @results.transform_values { _1.to_a.sort }.sort.to_h
     def to_yaml = results.to_yaml
   end

--- a/lib/test_map/test_task.rb
+++ b/lib/test_map/test_task.rb
@@ -15,6 +15,13 @@ module TestMap
       @name = name
     end
 
+    # Adapter for rspec test task
+    class RailsTestTask
+      attr_accessor :files
+
+      def call = Rails::TestUnit::Runner.run_from_rake('test', files)
+    end
+
     # Adapter for minitest test task.
     class MinitestTask < Minitest::TestTask
       def call = ruby(make_test_cmd, verbose: false)
@@ -38,7 +45,8 @@ module TestMap
         desc 'Run tests for changed files'
         task :changes do
           out_file = "#{Dir.pwd}/.test-map.yml"
-          test_files = Mapping.new(out_file).lookup(*ARGV[1..])
+          args = defined?(Rails) ? ENV['TEST']&.split : ARGV[1..]
+          test_files = Mapping.new(out_file).lookup(*args)
 
           # puts "Running tests #{test_files.join(' ')}"
           test_task.files = test_files
@@ -50,7 +58,10 @@ module TestMap
     def test_task = @test_task ||= build_test_task
 
     def build_test_task
-      if defined?(Minitest)
+      if defined?(Rails)
+        return RailsTestTask.new
+      elsif defined?(Minitest)
+        require 'minitest/test_task'
         return MinitestTask.new
       elsif defined?(RSpec)
         return RSpecTask.new

--- a/test/fixtures/sample.rb
+++ b/test/fixtures/sample.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# A sample Ruby class
+class Sample
+  def hello = 'Hello, World!'
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+
 require 'minitest/autorun'
 require 'test_map'

--- a/test/test_map/config_test.rb
+++ b/test/test_map/config_test.rb
@@ -13,6 +13,13 @@ class ConfigTest < Minitest::Test
     assert_kind_of Logger, subject.config[:logger]
   end
 
+  def test_ensure_default_keys
+    expected_keys = %i[logger out_file exclude_patterns natural_mapping
+                       skip_files merge]
+
+    assert_equal expected_keys, subject.config.keys
+  end
+
   private
 
   def subject = TestMap::Config

--- a/test/test_map/file_recorder_test.rb
+++ b/test/test_map/file_recorder_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'fixtures/sample'
 
 # Tests for file recorder.
 class FileRecorderTest < Minitest::Test
@@ -21,6 +22,18 @@ class FileRecorderTest < Minitest::Test
     subject.stop
 
     assert_equal 'file_recorder.rb', File.basename(subject.results.last)
+  end
+
+  def test_tracing_sample
+    subject.trace { Sample.new.hello }
+
+    assert_equal 'sample.rb', File.basename(subject.results.first)
+  end
+
+  def test_tracing_in_block_mode
+    subject.trace { Sample.new.hello }
+
+    refute_predicate subject.instance_variable_get(:@trace), :enabled?
   end
 
   private

--- a/test/test_map/natural_mapping_test.rb
+++ b/test/test_map/natural_mapping_test.rb
@@ -16,6 +16,10 @@ class NaturalMappingTest < Minitest::Test
     assert_equal ['test/model/animal_test.rb'], mapping.test_files
   end
 
+  def test_registered_rules
+    refute_empty subject.registered_rules
+  end
+
   def test_specs
     File.stub(:exist?, ->(type) { type == 'spec' }) do
       mapping = subject.new('app/model/animal.rb')

--- a/test/test_map_test.rb
+++ b/test/test_map_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class TestMeme < Minitest::Test
+class TestMapTest < Minitest::Test
   def test_presence_of_version_number
     refute_nil TestMap::VERSION
   end


### PR DESCRIPTION
Changes extend documentation of the project and extend it by providing a test-task (via Rake) that focuses to run tests of associated changed files. Includes extraction of release job in CI.