### PR TITLE
Optimize execution by reducing excessive calls and calculations

### DIFF
--- a/lib/test_map/cache.rb
+++ b/lib/test_map/cache.rb
@@ -12,13 +12,16 @@ module TestMap
       @cache_file = cache_file
       @map_file = map_file
       @root = root
+      @global_files_changed = nil
+      @current_checksums = {}
+      @file_exists_cache = {}
     end
 
     def fresh?(test_file)
       return false unless cached_checksums
       return false if global_files_changed?
 
-      files_to_check = [test_file] + source_files_for(test_file)
+      files_to_check = [test_file].concat(source_files_for(test_file))
       files_to_check.all? { |f| file_exist?(f) && current_checksum(f) == cached_checksums[f] }
     end
 
@@ -37,7 +40,8 @@ module TestMap
     end
 
     def global_files_changed?
-      GLOBAL_FILES.any? do |f|
+      return @global_files_changed unless @global_files_changed.nil?
+      @global_files_changed = GLOBAL_FILES.any? do |f|
         file_exist?(f) && current_checksum(f) != cached_checksums[f]
       end
     end
@@ -60,10 +64,12 @@ module TestMap
     end
 
     def current_checksum(file)
-      Digest::SHA256.file(File.join(@root, file)).hexdigest
+      @current_checksums[file] ||= Digest::SHA256.file(File.join(@root, file)).hexdigest
     end
 
-    def file_exist?(file) = File.exist?(File.join(@root, file))
+    def file_exist?(file)
+      @file_exists_cache[file] ||= File.exist?(File.join(@root, file))
+    end
 
     def collect_tracked_files(results)
       sources = results.keys

--- a/lib/test_map/file_recorder.rb
+++ b/lib/test_map/file_recorder.rb
@@ -26,8 +26,9 @@ module TestMap
     def results
       raise NotTracedError.default unless @trace
 
-      @files.filter { _1.start_with? Dir.pwd }
-            .map { _1.sub("#{Dir.pwd}/", '') }
+      cwd = "#{Dir.pwd}/"
+      @files.filter { _1.start_with? cwd }
+            .map { _1.sub(cwd, '') }
             .then { Filter.call _1 }
     end
   end


### PR DESCRIPTION
* The file recorder calls `Dir.pwd` many times although its values doesn't change. So we move that call out of the loops.

* The `TestMap::Cache` class can not just use the cache from the previous runs but also cache the values of the current run. This avoid excessive system calls and calculations.

A quick test with ruby-prof on TestMap's own test suite shows:

Changes in calls on initial run:
* `Dir.pwd`: 7139 -> 84
* `File.exist?`: 199 -> 151

Changes in calls on rerun:
* `Dir.pwd`: 43 -> 43
* `File.exist?`: 288 -> 32

This should translate to quite massive savings when the number of files increases.