### PR TITLE
Avoid allocations and calls for non-debug runs

### DIFF
--- a/lib/test_map/file_recorder.rb
+++ b/lib/test_map/file_recorder.rb
@@ -9,7 +9,7 @@ module TestMap
       raise TraceInUseError.default if @trace&.enabled?
 
       @trace = TracePoint.new(:call) do |tp|
-        TestMap.logger.debug "#{tp.path}:#{tp.lineno}"
+        TestMap.logger.debug { "#{tp.path}:#{tp.lineno}" }
         @files << tp.path
       end
 


### PR DESCRIPTION
The current implementation evaluates `"#{tp.path}:#{tp.lineno}"` on each call even if debug logging is not turned on. By using the block form, we avoid at least two method calls and two string allocations each time a trace point event fires.

I benchmarked using the `memory_profiler` gem. Before this change the line would allocate 28.808 strings, afterwards 0.