### PR TITLE
Use Set instead of an Array for tracking files

### DIFF
--- a/lib/test_map/file_recorder.rb
+++ b/lib/test_map/file_recorder.rb
@@ -3,7 +3,7 @@
 module TestMap
   # FileRecorder records files accessed during test execution.
   class FileRecorder
-    def initialize = @files = []
+    def initialize = @files = Set.new
 
     def trace(&block)
       raise TraceInUseError.default if @trace&.enabled?


### PR DESCRIPTION
Using `Array#<<` will add duplicate entries for files whereas `Set#<<` will store only a single entry for each unique file.

This reduces a) the size of `@files` and b) the needed processing time in #results.